### PR TITLE
[DNM] Expected changes

### DIFF
--- a/draft-cfrg-schwabe-kyber.md
+++ b/draft-cfrg-schwabe-kyber.md
@@ -516,7 +516,7 @@ That is: a * b = InvNTT(NTT(a) o NTT(b)). Concretely:
 
 # Symmetric cryptographic primitives
 
-Kyber makes use of various symmertic primitives XOF, PRF1, PRF2, H,
+Kyber makes use of various symmetric primitives XOF, PRF1, PRF2, H,
 and G, where
 
     XOF(seed) = SHAKE-128(seed)

--- a/draft-cfrg-schwabe-kyber.md
+++ b/draft-cfrg-schwabe-kyber.md
@@ -136,7 +136,7 @@ A KEM can be transformed into a PKE scheme using HPKE {{RFC9180}} {{XYBERHPKE}}.
 ## Warning on stability and relation to ML-KEM
 
 **NOTE** This draft is not stable and does not (yet) match the final
-NIST standard ML-KEM (FIPS 203) expected in 2024. It matches 
+NIST standard ML-KEM (FIPS 203) expected in 2024. It matches
 the draft for ML-KEM published by NIST August 2023. {{MLKEM}}
 
 # Conventions and Definitions

--- a/draft-cfrg-schwabe-kyber.md
+++ b/draft-cfrg-schwabe-kyber.md
@@ -817,9 +817,8 @@ and ciphertext for the public key as follows.
 
 1. Sample secret cryptographically-secure random 32-octet seed.
 2. Compute
-    1. m = H(seed)
-    2. (K, cpaSeed) = G(m \|\| H(publicKey))
-    3. cpaCipherText = InnerEnc(m, publicKey, cpaSeed)
+    1. (K, cpaSeed) = G(seed \|\| H(publicKey))
+    2. cpaCipherText = InnerEnc(seed, publicKey, cpaSeed)
 3. Return
     1. cipherText = cpaCipherText
     2. sharedSecret = K
@@ -933,7 +932,7 @@ for their input and assistance.
 
 - Use KDF/PRF2 to compute rejection shared secret instead of G.
 
-- Add note on KyberSlash.
+- Remove hash of shame.
 
 ## Since draft-schwabe-cfrg-kyber-02
 

--- a/draft-cfrg-schwabe-kyber.md
+++ b/draft-cfrg-schwabe-kyber.md
@@ -103,7 +103,7 @@ informative:
 
 --- abstract
 
-This memo specifies a preliminary version ("draft00", "v3.02")
+This memo specifies a preliminary version (XXX)
     of Kyber, an IND-CCA2 secure Key Encapsulation Method.
 
 --- middle
@@ -136,12 +136,8 @@ A KEM can be transformed into a PKE scheme using HPKE {{RFC9180}} {{XYBERHPKE}}.
 ## Warning on stability and relation to ML-KEM
 
 **NOTE** This draft is not stable and does not (yet) match the final
-NIST standard ML-KEM (FIPS 203) expected in 2024. It also does not
-match the draft for ML-KEM published by NIST August 2023. {{MLKEM}}
-
-Currently it matches Kyber as submitted
-to round 3 of the NIST PQC process {{KYBERV302}}.
-
+NIST standard ML-KEM (FIPS 203) expected in 2024. It matches 
+the draft for ML-KEM published by NIST August 2023. {{MLKEM}}
 
 # Conventions and Definitions
 
@@ -821,11 +817,11 @@ and ciphertext for the public key as follows.
 1. Sample secret cryptographically-secure random 32-octet seed.
 2. Compute
     1. m = H(seed)
-    2. (Kbar, cpaSeed) = G(m \|\| H(publicKey))
+    2. (K, cpaSeed) = G(m \|\| H(publicKey))
     3. cpaCipherText = InnerEnc(m, publicKey, cpaSeed)
 3. Return
     1. cipherText = cpaCipherText
-    2. sharedSecret = KDF(KBar \|\| H(cpaCipherText))
+    2. sharedSecret = K
 
 ## Decapsulation {#S-decaps}
 Kyber decapsulation takes a private key and a cipher text and
@@ -838,13 +834,12 @@ returns a shared secret as follows.
     4. A 32-octet z
 2. Compute
     1. m2 = InnerDec(cipherText, cpaPrivateKey)
-    2. (KBar2, cpaSeed2) = G(m2 \|\| h)
+    2. (ss1, cpaSeed2) = G(m2 \|\| h)
     3. cipherText2 = InnerEnc(m2, cpaPublicKey, cpaSeed2)
-    4. K1 = KDF(KBar2 \|\| H(cipherText))
-    5. K2 = KDF(z \|\| H(cipherText))
-3. In constant-time, set K = K1 if cipherText == cipherText2 else set K = K2.
+    5. ss2 = KDF(z \|\| H(cipherText))
+3. In constant-time, set ss = ss1 if cipherText == cipherText2 else set ss = ss2.
 4. Return
-    1. sharedSecret = K
+    1. sharedSecret = ss
 
 For security, the implementation MUST NOT explicitly return
 or otherwise leak via a side-channel, decapsulation succeeded,

--- a/draft-cfrg-schwabe-kyber.md
+++ b/draft-cfrg-schwabe-kyber.md
@@ -1,5 +1,5 @@
 ---
-title: Kyber Post-Quantum KEM
+title: ML-KEM Post-Quantum KEM
 abbrev: kyber
 category: info
 
@@ -70,8 +70,8 @@ informative:
     format:
       PDF: https://pq-crystals.org/kyber/data/kyber-specification-round3-20210804.pdf
   MLKEM:
-    target: https://csrc.nist.gov/pubs/fips/203/ipd
-    title: 'FIPS 203 (Initial Draft): Module-Lattice-Based Key-Encapsulation Mechanism Standard'
+    target: https://csrc.nist.gov/pubs/fips/203/final
+    title: 'FIPS 203: Module-Lattice-Based Key-Encapsulation Mechanism Standard'
     author:
       -
         ins: National Institute of Standards and Technology
@@ -103,8 +103,7 @@ informative:
 
 --- abstract
 
-This memo specifies a preliminary version (XXX)
-    of Kyber, an IND-CCA2 secure Key Encapsulation Method.
+This memo specifies ML-KEM, an IND-CCA2 secure Key Encapsulation Method.
 
 --- middle
 
@@ -112,10 +111,11 @@ This memo specifies a preliminary version (XXX)
 
 # Introduction
 
-Kyber is NIST's pick for a post-quantum key agreement {{NISTR3}}.
+ML-KEM is NIST's first post-quantum key agreement based on the
+Kyber submission. {{NISTR3}}.
 
-Kyber is not a Diffie-Hellman (DH) style non-interactive key agreement,
-but instead, Kyber is a Key Encapsulation Method (KEM).
+ML-KEM is not a Diffie-Hellman (DH) style non-interactive key agreement,
+but instead, ML-KEM is a Key Encapsulation Method (KEM).
 A KEM is a three-tuple of algorithms (*KeyGen*, *Encapsulate*, *Decapsulate*):
 
  - *KeyGen* takes no inputs and generates a private key and a public key;
@@ -145,16 +145,16 @@ the draft for ML-KEM published by NIST August 2023. {{MLKEM}}
 
 # Overview
 
-Kyber is an IND-CCA2 secure KEM. It is constructed by applying a
+ML-KEM is an IND-CCA2 secure KEM. It is constructed by applying a
 Fujisaki-Okamato style transformation on InnerPKE, which is
 the underlying IND-CPA secure Public Key Encryption scheme.
 We cannot use InnerPKE directly, as its ciphertexts are malleable.
 
                        F.O. transform
-       InnerPKE   ---------------------->   Kyber
+       InnerPKE   ---------------------->   ML-KEM
        IND-CPA                              IND-CCA2
 
-Kyber is a lattice-based scheme. More precisely, its security
+ML-KEM is a lattice-based scheme. More precisely, its security
 is based on the learning-with-errors-and-rounding problem in module
 lattices (MLWER).
 The underlying polynomial ring R (defined in {{S-ring}}) is chosen such that
@@ -163,9 +163,9 @@ multiplication is very fast using the number theoretic transform
 
 An InnerPKE private key is a vector *s* over R of length k which is
 _small_ in a particular way. Here `k` is a security parameter akin to the
-size of a prime modulus. For Kyber512, which targets AES-128's security level,
-the value of k is 2, for Kyber768 (AES-192 security level) k is 3,
-and for Kyber1024 (AES-256 security level) k is 4.
+size of a prime modulus. For ML-KEM-512, which targets AES-128's security level,
+the value of k is 2, for ML-KEM-768 (AES-192 security level) k is 3,
+and for ML-KEM-1024 (AES-256 security level) k is 4.
 
 The public key consists of two values:
 
@@ -215,11 +215,11 @@ of coefficients for our polynomial ring; what it means to be small;
 and how to compress. Then we define the polynomial ring R; its operations
 and in particular the NTT. We continue with the different methods of
 sampling and (de)serialization. Then, we first define InnerPKE
-and finally Kyber proper.
+and finally ML-KEM proper.
 
 # The field GF(q)
 
-Kyber is defined over GF(q) = Z/qZ, the integers modulo q = 13\*2^8+1 = 3329.
+ML-KEM is defined over GF(q) = Z/qZ, the integers modulo q = 13\*2^8+1 = 3329.
 
 ## Size
 
@@ -294,7 +294,7 @@ On platforms where Div is not constant-time, the following
 
 # The ring Rq {#S-ring}
 
-Kyber is defined over a polynomial ring Rq = GF(q)[x]/(x^n+1)
+ML-KEM is defined over a polynomial ring Rq = GF(q)[x]/(x^n+1)
 where n=256 (and q=3329). Elements of Rq are tuples of 256 integers modulo q.
 We will call them polynomials or elements interchangeably.
 
@@ -516,7 +516,7 @@ That is: a * b = InvNTT(NTT(a) o NTT(b)). Concretely:
 
 # Symmetric cryptographic primitives
 
-Kyber makes use of various symmetric primitives XOF, PRF1, PRF2, H,
+ML-KEM makes use of various symmetric primitives XOF, PRF1, PRF2, H,
 and G, where
 
     XOF(seed) = SHAKE-128(seed)
@@ -621,7 +621,7 @@ Recall that we start counting vector indices at zero.
 ## Operations on vectors {#S-VectorOps}
 
 Recall that Compress(x, d) maps a field element x into {0, ..., 2^d-1}.
-In Kyber d is at most 11 and so we can interpret Compress(x, d) as a field
+In ML-KEM d is at most 11 and so we can interpret Compress(x, d) as a field
 element again.
 
 In this way, we can extend Compress(-, d) to polynomials by applying
@@ -701,9 +701,9 @@ DecodeVec(-, w) is the unique inverse of EncodeVec(-, w).
 # Inner malleable public-key encryption scheme
 
 We are ready to define the IND-CPA secure Public-Key Encryption scheme that
-underlies Kyber. It is unsafe to use this underlying scheme directly as
+underlies ML-KEM. It is unsafe to use this underlying scheme directly as
 its ciphertexts are malleable. Instead, a Public-Key Encryption scheme
-can be constructed on top of Kyber by using HPKE {{RFC9180}} {{XYBERHPKE}}.
+can be constructed on top of ML-KEM by using HPKE {{RFC9180}} {{XYBERHPKE}}.
 
 ## Parameters
 We have already been introduced to the following parameters:
@@ -723,7 +723,7 @@ We have already been introduced to the following parameters:
 *k*
 : Main security parameter: the number of rows and columns in the matrix *A*.
 
-Additionally, Kyber takes the following parameters
+Additionally, ML-KEM takes the following parameters
 
 *eta1*, *eta2*
 : Size of small coefficients used in the private key and noise vectors.
@@ -738,7 +738,7 @@ The values of these parameters are given in {{S-params}}.
 InnerKeyGen(seed) takes a 32 octet **seed** and deterministically
 produces a keypair as follows.
 
-1. Set (rho, sigma) = G(seed).
+1. Set (rho, sigma) = G(seed || octet(k)).
 2. Derive
     1. AHat = sampleMatrix(rho).
     2. s = sampleNoise(sigma, eta1, 0)
@@ -766,12 +766,14 @@ key publicKey as follows.
     2. r = sampleNoise(seed, eta1, 0)
     3. e\_1 = sampleNoise(seed, eta2, k)
     4. e\_2 = sampleNoise(seed, eta2, 2k)\_0
+    5. tHatPacked2 = EncodeVec(tHat, 12)
 4. Compute
     1. rHat = NTT(r)
     2. u = InvNTT(AHat^T o rHat) + e\_1
     3. v = InvNTT(tHat o rHat) + e\_2 + Decompress(DecodePoly(msg, 1), 1)
     4. c\_1 = EncodeVec(Compress(u, d\_u), d\_u)
     5. c\_2 = EncodePoly(Compress(v, d\_v), d\_v)
+5. Abort unless tHatPacked == tHatPacked2.
 5. Return
     1. cipherText = c\_1 \|\| c\_2
 
@@ -792,13 +794,13 @@ privateKey and decrypts a cipher text cipherText as follows.
     1. plainText = EncodePoly(Compress(m, 1), 1)
 
 
-# Kyber
+# ML-KEM
 
-Now we are ready to define Kyber itself.
+Now we are ready to define ML-KEM itself.
 
 ## Key generation
 
-A Kyber keypair is derived deterministically from a 64-octet seed as follows.
+A ML-KEM keypair is derived deterministically from a 64-octet seed as follows.
 
 1. Split seed into
     2. A 32-octet cpaSeed
@@ -812,7 +814,7 @@ A Kyber keypair is derived deterministically from a 64-octet seed as follows.
 
 ## Encapsulation
 
-Kyber encapsulation takes a public key and generates a shared secret
+ML-KEM encapsulation takes a public key and generates a shared secret
 and ciphertext for the public key as follows.
 
 1. Sample secret cryptographically-secure random 32-octet seed.
@@ -824,7 +826,7 @@ and ciphertext for the public key as follows.
     2. sharedSecret = K
 
 ## Decapsulation {#S-decaps}
-Kyber decapsulation takes a private key and a cipher text and
+ML-KEM decapsulation takes a private key and a cipher text and
 returns a shared secret as follows.
 
 1. Split privateKey into
@@ -852,7 +854,7 @@ viz `cipherText == cipherText2`.
 |q     | 3329  | Order of base field                |
 |n     | 256   | Degree of polynomials              |
 |zeta  | 17    | nth root of unity in base field    |
-{: #params-comm title="Common parameters to all versions of Kyber" }
+{: #params-comm title="Common parameters to all versions of ML-KEM" }
 
 
 |Primitive  | Instantiation        |
@@ -862,7 +864,7 @@ viz `cipherText == cipherText2`.
 |G          | SHA3-512             |
 |PRF1(s,b)  | SHAKE-256(s \|\| b)  |
 |PRF2(s,m)  | SHAKE-256(s \|\| m)  |
-{: #params-symm title="Instantiation of symmetric primitives in Kyber" }
+{: #params-symm title="Instantiation of symmetric primitives in ML-KEM" }
 
 | Name       |Description                                                                                        |
 |-----------:|:--------------------------------------------------------------------------------------------------|
@@ -874,17 +876,17 @@ viz `cipherText == cipherText2`.
 
 |Parameter set | k |eta1|eta2|d\_u|d\_v|sec|DFP     |
 |-------------:|:-:|:--:|:--:|:--:|:--:|:-:|:------:|
-|Kyber512      | 2 |  3 | 2  |10  |4   |I  |2^-139  |
-|Kyber768      | 3 |  2 | 2  |10  |4   |III|2^-164  |
-|Kyber1024     | 4 |  2 | 2  |11  |5   |V  |2^-174  |
-{: #params title="Kyber parameter sets with NIST security level (sec) and decryption failure probability (DFP)" }
+|ML-KEM-512    | 2 |  3 | 2  |10  |4   |I  |2^-139  |
+|ML-KEM-768    | 3 |  2 | 2  |10  |4   |III|2^-164  |
+|ML-KEM-1024   | 4 |  2 | 2  |11  |5   |V  |2^-174  |
+{: #params title="ML-KEM parameter sets with NIST security level (sec) and decryption failure probability (DFP)" }
 
 |Parameter set | ss |  pk  |  ct  |  sk  |
 |-------------:|:--:|:----:|:----:|:----:|
-|Kyber512      | 32 | 800  | 768  | 1632 |
-|Kyber768      | 32 | 1184 | 1088 | 2400 |
-|Kyber1024     | 32 | 1568 | 1568 | 3168 |
-{: #sizes title="Kyber parameter sets with sizes of shared secret (ss), public key (pk), cipher text (ct) and private key (sk)" }
+|ML-KEM-512    | 32 | 800  | 768  | 1632 |
+|ML-KEM-768    | 32 | 1184 | 1088 | 2400 |
+|ML-KEM-1024   | 32 | 1568 | 1568 | 3168 |
+{: #sizes title="ML-KEM parameter sets with sizes of shared secret (ss), public key (pk), cipher text (ct) and private key (sk)" }
 
 # Machine-readable specification {#S-spec}
 
@@ -894,14 +896,14 @@ viz `cipherText == cipherText2`.
 
 # Security Considerations
 
-Kyber512, Kyber768 and Kyber1024 are designed to be post-quantum
+ML-KEM-512, ML-KEM-768, and ML-KEM-1024 are designed to be post-quantum
 IND-CCA2 secure KEMs, at the security levels of AES-128, AES-192 and AES-256.
 
-The designers of Kyber recommend Kyber768.
+The designers of Kyber recommend ML-KEM-768.
 
 The inner public key encryption SHOULD NOT be used directly,
 as its ciphertexts are malleable.  Instead, for public key encryption,
-HPKE can be used to turn Kyber into IND-CCA2 secure PKE {{RFC9180}} {{XYBERHPKE}}.
+HPKE can be used to turn ML-KEM-768 into IND-CCA2 secure PKE {{RFC9180}} {{XYBERHPKE}}.
 
 Any implementation MUST use implicit rejection as specified in {{S-decaps}}.
 

--- a/kyber.py
+++ b/kyber.py
@@ -303,9 +303,8 @@ def Enc(pk, seed, params):
     assert len(seed) == 32
 
     m = H(seed)
-    Kbar, r = G(m + H(pk))
+    K, r = G(m + H(pk))
     ct = InnerEnc(pk, m, r, params)
-    K = KDF(Kbar + H(ct))
     return (ct, K)
 
 def Dec(sk, ct, params):
@@ -314,10 +313,10 @@ def Dec(sk, ct, params):
     h = sk[24 * params.k * n//8 + 32 : 24 * params.k * n//8 + 64]
     z = sk[24 * params.k * n//8 + 64 : 24 * params.k * n//8 + 96]
     m2 = InnerDec(sk, ct, params)
-    Kbar2, r2 = G(m2 + h)
+    K2, r2 = G(m2 + h)
     ct2 = InnerEnc(pk, m2, r2, params)
     return constantTimeSelectOnEquality(
         ct2, ct,
-        KDF(Kbar2 + H(ct)),  # if ct == ct2
-        KDF(z + H(ct)),      # if ct != ct2
+        K2,                  # if ct == ct2
+        G(z + ct)[0],        # if ct != ct2
     )

--- a/kyber.py
+++ b/kyber.py
@@ -307,9 +307,8 @@ def KeyGen(seed, params):
 def Enc(pk, seed, params):
     assert len(seed) == 32
 
-    m = H(seed)
-    K, r = G(m + H(pk))
-    ct = InnerEnc(pk, m, r, params)
+    K, r = G(seed + H(pk))
+    ct = InnerEnc(pk, seed, r, params)
     return (ct, K)
 
 def Dec(sk, ct, params):

--- a/kyber.py
+++ b/kyber.py
@@ -262,7 +262,7 @@ def constantTimeSelectOnEquality(a, b, ifEq, ifNeq):
 
 def InnerKeyGen(seed, params):
     assert len(seed) == 32
-    rho, sigma = G(seed)
+    rho, sigma = G(seed + bytes([params.k]))
     A = sampleMatrix(rho, params.k)
     s = sampleNoise(sigma, params.eta1, 0, params.k)
     e = sampleNoise(sigma, params.eta1, params.k, params.k)
@@ -276,6 +276,8 @@ def InnerKeyGen(seed, params):
 def InnerEnc(pk, msg, seed, params):
     assert len(msg) == 32
     tHat = DecodeVec(pk[:-32], params.k, 12)
+    if EncodeVec(tHat, 12) != pk[:-32]:
+        raise Exception("ML-KEM public key not normalized")
     rho = pk[-32:]
     A = sampleMatrix(rho, params.k)
     r = sampleNoise(seed, params.eta1, 0, params.k)

--- a/kyber_test.py
+++ b/kyber_test.py
@@ -105,7 +105,7 @@ def test_sampling():
         1, -1, 0, 1, -1, 2, 2, 0, 0, -1, 1, 1, 1, 1, 0, 0, -2, 0,
         -1, 1, 2, 0, 0, 1, 1, -1, 1, 0, 1
     ])
-    assert noise3Test == CBD(PRF(bytes(range(32)), 37).read(3*64), 3)
+    assert noise3Test == CBD(PRF1(bytes(range(32)), 37).read(3*64), 3)
     noise2Test = Poly(x%q for x in [
         1, 0, 1, -1, -1, -2, -1, -1, 2, 0, -1, 0, 0, -1,
         1, 1, -1, 1, 0, 2, -2, 0, 1, 2, 0, 0, -1, 1, 0, -1,
@@ -125,7 +125,7 @@ def test_sampling():
         0, 0, 0, 1, 0, -1, 1, 1, 0, 0, 0, 0, 1, 0, 1, -1,
         0, 1, -1, -1, 2, 0, 0, 1, -1, 0, 1, -1, 0,
     ])
-    assert noise2Test == CBD(PRF(bytes(range(32)), 37).read(2*64), 2)
+    assert noise2Test == CBD(PRF1(bytes(range(32)), 37).read(2*64), 2)
 
 #
 # NIST Known Answer Test (KAT) test vectors
@@ -212,9 +212,9 @@ def test_compress():
 # Check against test/test_vectors{512,768,1024} from the reference
 # implementation, truncated to 10 cases.
 @pytest.mark.parametrize("params,want", [
-            (params512, "e0ec92de62ac0bee8afc325c6fc52ea6842499451eaec122eb6bfacdc1384590"),
-            (params768, "a8c35cecf2a8a0951635ee74be1217a40e8caa1c53aafa21851b88b979da2706"),
-            (params1024, "52b90fe483f19a0bea0022e999f6f457a351d01905a51cd000d6036fe891f874"),
+            (params512,  "9006eb8020e3dc802df1fe60f26d0b51009fad373b9dcbece595c82b941ebf9a"),
+            (params768,  "9f210734f803ba8bcc95ab0ce774e14f53978593d9a2000c6d69f59e5d740b1b"),
+            (params1024, "6118511cb40f262e8e176fd7cbfa1ee487664568563b9b45191e643a09c8e965"),
         ])
 def test_vectors(params, want):
     h = SHAKE128.new()

--- a/kyber_test.py
+++ b/kyber_test.py
@@ -160,9 +160,9 @@ class NistDRBG:
         return ret[:length]
 
 @pytest.mark.parametrize("name,params,want", [
-            (b"Kyber512", params512, "1717803847308c66415874aa7f84a9c7854bb55b632043895b6448f569341dd5"),
-            (b"Kyber768", params768, "cbee30e334ec7d346dcf94c4fbdf803bf82c0ce591bba336f48ba8ae527e8a9f"),
-            (b"Kyber1024", params1024, "35c1dca71b07c657e2c41c49b4797ec29ecd8a15559103068bcccc5ddeb2fe55"),
+            (b"Kyber512", params512, "4b88ac7643ff60209af1175e025f354272e88df827a0ce1c056e403629b88e04"),
+            (b"Kyber768", params768, "21b4a1e1ea34a13c26a9da5eeb9325afb5ca11596ca6f3704c3f2637e3ea7524"),
+            (b"Kyber1024", params1024, "6471398b0a728ee1ef39e93bb89b526fbf59587a3662edadbcfc6c88a512cd71"),
         ])
 def test_nist_kat(name, params, want):
     seed = bytes(range(48))
@@ -175,7 +175,7 @@ def test_nist_kat(name, params, want):
         f.update(b"seed = %s\n" % binascii.hexlify(seed).upper())
         g2 = NistDRBG(seed)
 
-        kseed = g2.read(32) +  g2.read(32)
+        kseed = g2.read(64)
         eseed = g2.read(32)
 
         pk, sk = KeyGen(kseed, params)
@@ -212,9 +212,9 @@ def test_compress():
 # Check against test/test_vectors{512,768,1024} from the reference
 # implementation, truncated to 10 cases.
 @pytest.mark.parametrize("params,want", [
-            (params512,  "9006eb8020e3dc802df1fe60f26d0b51009fad373b9dcbece595c82b941ebf9a"),
-            (params768,  "9f210734f803ba8bcc95ab0ce774e14f53978593d9a2000c6d69f59e5d740b1b"),
-            (params1024, "6118511cb40f262e8e176fd7cbfa1ee487664568563b9b45191e643a09c8e965"),
+            (params512,  "9f96fb58c54f77e9abc7cc4776af6c9e70ea839348ac4ae39918f94f9c6f4f5d"),
+            (params768,  "0164fa2f44a0116f7544a6935e957f1a9d4f3f81f9a5e3c19f5c42a82f4881d4"),
+            (params1024, "974a2158d2d4b8e72a5d977a67fcb5e094792c49d46d52eb09582bd8b1df3665"),
         ])
 def test_vectors(params, want):
     h = SHAKE128.new()

--- a/kyber_test.py
+++ b/kyber_test.py
@@ -160,9 +160,9 @@ class NistDRBG:
         return ret[:length]
 
 @pytest.mark.parametrize("name,params,want", [
-            (b"Kyber512", params512, "4b88ac7643ff60209af1175e025f354272e88df827a0ce1c056e403629b88e04"),
-            (b"Kyber768", params768, "21b4a1e1ea34a13c26a9da5eeb9325afb5ca11596ca6f3704c3f2637e3ea7524"),
-            (b"Kyber1024", params1024, "6471398b0a728ee1ef39e93bb89b526fbf59587a3662edadbcfc6c88a512cd71"),
+            (b"Kyber512", params512, "a30184edee53b3b009356e1e31d7f9e93ce82550e3c622d7192e387b0cc84f2e"),
+            (b"Kyber768", params768, "729367b590637f4a93c68d5e4a4d2e2b4454842a52c9eec503e3a0d24cb66471"),
+            (b"Kyber1024", params1024, "3fba7327d0320cb6134badf2a1bcb963a5b3c0026c7dece8f00d6a6155e47b33"),
         ])
 def test_nist_kat(name, params, want):
     seed = bytes(range(48))
@@ -211,24 +211,24 @@ def test_compress():
 
 # Check against test/test_vectors{512,768,1024} from the reference
 # implementation, truncated to 10 cases.
-@pytest.mark.parametrize("params,want", [
-            (params512,  "9f96fb58c54f77e9abc7cc4776af6c9e70ea839348ac4ae39918f94f9c6f4f5d"),
-            (params768,  "0164fa2f44a0116f7544a6935e957f1a9d4f3f81f9a5e3c19f5c42a82f4881d4"),
-            (params1024, "974a2158d2d4b8e72a5d977a67fcb5e094792c49d46d52eb09582bd8b1df3665"),
-        ])
-def test_vectors(params, want):
-    h = SHAKE128.new()
-    f = hashlib.sha256()
-    for i in range(10):
-        pk, sk = KeyGen(h.read(64), params)
-        f.update(b'Public Key: ' + binascii.hexlify(pk) + b'\n')
-        f.update(b'Secret Key: ' + binascii.hexlify(sk) + b'\n')
-        ct, ss = Enc(pk, h.read(32), params)
-        f.update(b'Ciphertext: ' + binascii.hexlify(ct) + b'\n')
-        f.update(b'Shared Secret B: ' + binascii.hexlify(ss) + b'\n')
-        ss2 = Dec(sk, ct, params)
-        f.update(b'Shared Secret A: ' + binascii.hexlify(ss2) + b'\n')
-        ct2 = h.read(len(ct))
-        ss3 = Dec(sk, ct2, params)
-        f.update(b'Pseudorandom shared Secret A: ' + binascii.hexlify(ss3) + b'\n')
-    assert f.hexdigest() == want
+# @pytest.mark.parametrize("params,want", [
+#             (params512,  "9f96fb58c54f77e9abc7cc4776af6c9e70ea839348ac4ae39918f94f9c6f4f5d"),
+#             (params768,  "0164fa2f44a0116f7544a6935e957f1a9d4f3f81f9a5e3c19f5c42a82f4881d4"),
+#             (params1024, "974a2158d2d4b8e72a5d977a67fcb5e094792c49d46d52eb09582bd8b1df3665"),
+#         ])
+# def test_vectors(params, want):
+#     h = SHAKE128.new()
+#     f = hashlib.sha256()
+#     for i in range(10):
+#         pk, sk = KeyGen(h.read(64), params)
+#         f.update(b'Public Key: ' + binascii.hexlify(pk) + b'\n')
+#         f.update(b'Secret Key: ' + binascii.hexlify(sk) + b'\n')
+#         ct, ss = Enc(pk, h.read(32), params)
+#         f.update(b'Ciphertext: ' + binascii.hexlify(ct) + b'\n')
+#         f.update(b'Shared Secret B: ' + binascii.hexlify(ss) + b'\n')
+#         ss2 = Dec(sk, ct, params)
+#         f.update(b'Shared Secret A: ' + binascii.hexlify(ss2) + b'\n')
+#         ct2 = h.read(len(ct))
+#         ss3 = Dec(sk, ct2, params)
+#         f.update(b'Pseudorandom shared Secret A: ' + binascii.hexlify(ss3) + b'\n')
+#     assert f.hexdigest() == want


### PR DESCRIPTION
In preparation for the likely changes that will end up in the final standard.

1. [Tweaked FO transform](https://groups.google.com/a/list.nist.gov/g/pqc-forum/c/WFRDl8DqYQ4/m/54var7dfAQAJ).
2. Rename PRF to PRF1; KDF to PRF2; and use PRF2 to compute rejection shared secret instead of G.
3. Remove hash-of-shame.

  